### PR TITLE
Remove non printable characters

### DIFF
--- a/AdGuard_games_list.txt
+++ b/AdGuard_games_list.txt
@@ -868,7 +868,7 @@ sites.google.com/site/unblockurgames
 ||barajando.com^
 ||barbie.everythinggirl.com^
 ||barbok.fr^
-||basketball.io^
+||basketball.io^
 ||baseattackforce.com^
 ||basketball-game.com^
 ||basketball-rpg.net^


### PR DESCRIPTION
Fix error that prevented AdguardHome from accepting the list.

Hidden characters were present in some line.